### PR TITLE
Varleniterator fix

### DIFF
--- a/cs/src/core/Allocator/GenericAllocator.cs
+++ b/cs/src/core/Allocator/GenericAllocator.cs
@@ -41,7 +41,8 @@ namespace FASTER.core
 
         private readonly OverflowPool<Record<Key, Value>[]> overflowPagePool;
 
-        public GenericAllocator(LogSettings settings, SerializerSettings<Key, Value> serializerSettings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null, LightEpoch epoch = null, Action<CommitInfo> flushCallback = null, ILogger logger = null)
+        public GenericAllocator(LogSettings settings, SerializerSettings<Key, Value> serializerSettings, IFasterEqualityComparer<Key> comparer, 
+                Action<long, long> evictCallback = null, LightEpoch epoch = null, Action<CommitInfo> flushCallback = null, ILogger logger = null)
             : base(settings, comparer, evictCallback, epoch, flushCallback, logger)
         {
             overflowPagePool = new OverflowPool<Record<Key, Value>[]>(4);
@@ -1078,21 +1079,16 @@ namespace FASTER.core
         /// <summary>
         /// Iterator interface for scanning FASTER log
         /// </summary>
-        /// <param name="beginAddress"></param>
-        /// <param name="endAddress"></param>
-        /// <param name="scanBufferingMode"></param>
         /// <returns></returns>
-        public override IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode)
-        {
-            return new GenericScanIterator<Key, Value>(this, beginAddress, endAddress, scanBufferingMode, epoch);
-        }
+        public override IFasterScanIterator<Key, Value> Scan(FasterKV<Key, Value> store, long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode) 
+            => new GenericScanIterator<Key, Value>(store, this, beginAddress, endAddress, scanBufferingMode, epoch);
 
         /// <summary>
         /// Implementation for push-scanning FASTER log, called from LogAccessor
         /// </summary>
         internal override bool Scan<TScanFunctions>(FasterKV<Key, Value> store, long beginAddress, long endAddress, ref TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
         {
-            using GenericScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+            using GenericScanIterator<Key, Value> iter = new(store, this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
             return PushScanImpl(store, beginAddress, endAddress, ref scanFunctions, iter);
         }
 
@@ -1101,7 +1097,7 @@ namespace FASTER.core
         /// </summary>
         internal override bool IterateKeyVersions<TScanFunctions>(FasterKV<Key, Value> store, ref Key key, long beginAddress, ref TScanFunctions scanFunctions)
         {
-            using GenericScanIterator<Key, Value> iter = new(this, store.comparer, beginAddress, epoch, logger: logger);
+            using GenericScanIterator<Key, Value> iter = new(store, this, store.comparer, beginAddress, epoch, logger: logger);
             return IterateKeyVersionsImpl(store, ref key, beginAddress, ref scanFunctions, iter);
         }
 

--- a/cs/src/core/Allocator/IScanIteratorFunctions.cs
+++ b/cs/src/core/Allocator/IScanIteratorFunctions.cs
@@ -14,7 +14,11 @@ namespace FASTER.core
         /// <param name="beginAddress">Start address of the scan</param>
         /// <param name="endAddress">End address of the scan; if iterating key versions, this is <see cref="Constants.kInvalidAddress"/></param>
         /// <returns>True to continue iteration, else false</returns>
-        bool OnStart(long beginAddress, long endAddress);
+        bool OnStart(long beginAddress, long endAddress)
+#if NETSTANDARD2_1 || NET
+            => true
+#endif
+            ;
 
         /// <summary>Next record in iteration for a record not in mutable log memory.</summary>
         /// <param name="key">Reference to the current record's key</param>
@@ -35,12 +39,22 @@ namespace FASTER.core
         /// <summary>Iteration is complete.</summary>
         /// <param name="completed">If true, the iteration completed; else scanFunctions.*Reader() returned false to stop the iteration.</param>
         /// <param name="numberOfRecords">The number of records returned before the iteration stopped.</param>
-        void OnStop(bool completed, long numberOfRecords);
+        void OnStop(bool completed, long numberOfRecords)
+#if NETSTANDARD2_1 || NET
+        { }
+#else
+            ;
+#endif
 
         /// <summary>An exception was thrown on iteration (likely during <see name="SingleReader"/> or <see name="ConcurrentReader"/>.</summary>
         /// <param name="exception">The exception that was thrown.</param>
         /// <param name="numberOfRecords">The number of records returned, including the current one, before the exception.</param>
-        void OnException(Exception exception, long numberOfRecords);
+        void OnException(Exception exception, long numberOfRecords)
+#if NETSTANDARD2_1 || NET
+        { }
+#else
+            ;
+#endif
     }
 
     internal interface IPushScanIterator<Key>

--- a/cs/src/core/Allocator/IScanIteratorFunctions.cs
+++ b/cs/src/core/Allocator/IScanIteratorFunctions.cs
@@ -14,11 +14,7 @@ namespace FASTER.core
         /// <param name="beginAddress">Start address of the scan</param>
         /// <param name="endAddress">End address of the scan; if iterating key versions, this is <see cref="Constants.kInvalidAddress"/></param>
         /// <returns>True to continue iteration, else false</returns>
-        bool OnStart(long beginAddress, long endAddress)
-#if NETSTANDARD2_1 || NET
-            => true
-#endif
-            ;
+        bool OnStart(long beginAddress, long endAddress);
 
         /// <summary>Next record in iteration for a record not in mutable log memory.</summary>
         /// <param name="key">Reference to the current record's key</param>
@@ -39,29 +35,18 @@ namespace FASTER.core
         /// <summary>Iteration is complete.</summary>
         /// <param name="completed">If true, the iteration completed; else scanFunctions.*Reader() returned false to stop the iteration.</param>
         /// <param name="numberOfRecords">The number of records returned before the iteration stopped.</param>
-        void OnStop(bool completed, long numberOfRecords)
-#if NETSTANDARD2_1 || NET
-        { }
-#else
-            ;
-#endif
+        void OnStop(bool completed, long numberOfRecords);
 
         /// <summary>An exception was thrown on iteration (likely during <see name="SingleReader"/> or <see name="ConcurrentReader"/>.</summary>
         /// <param name="exception">The exception that was thrown.</param>
         /// <param name="numberOfRecords">The number of records returned, including the current one, before the exception.</param>
-        void OnException(Exception exception, long numberOfRecords)
-#if NETSTANDARD2_1 || NET
-        { }
-#else
-            ;
-#endif
+        void OnException(Exception exception, long numberOfRecords);
     }
 
     internal interface IPushScanIterator<Key>
     {
-        bool BeginGetNext(out RecordInfo recordInfo);
         bool BeginGetPrevInMemory(ref Key key, out RecordInfo recordInfo, out bool continueOnDisk);
-        bool EndGet();
+        bool EndGetPrevInMemory();
         ref RecordInfo GetLockableInfo();
     }
 }

--- a/cs/src/core/Allocator/MemoryPageScanIterator.cs
+++ b/cs/src/core/Allocator/MemoryPageScanIterator.cs
@@ -6,7 +6,8 @@ using System;
 namespace FASTER.core
 {
     /// <summary>
-    /// Lightweight iterator for memory page (copied to buffer). GetNext() can be used outside epoch protection but ctor must be called within epoch protection.
+    /// Lightweight iterator for memory page (copied to buffer). GetNext() can be used outside epoch protection and locking,
+    /// but ctor must be called within epoch protection.
     /// </summary>
     /// <typeparam name="Key"></typeparam>
     /// <typeparam name="Value"></typeparam>

--- a/cs/src/core/Allocator/VarLenBlittableAllocator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableAllocator.cs
@@ -34,7 +34,8 @@ namespace FASTER.core
 
         private readonly OverflowPool<PageUnit> overflowPagePool;
 
-        public VariableLengthBlittableAllocator(LogSettings settings, VariableLengthStructSettings<Key, Value> vlSettings, IFasterEqualityComparer<Key> comparer, Action<long, long> evictCallback = null, LightEpoch epoch = null, Action<CommitInfo> flushCallback = null, ILogger logger = null)
+        public VariableLengthBlittableAllocator(LogSettings settings, VariableLengthStructSettings<Key, Value> vlSettings, IFasterEqualityComparer<Key> comparer, 
+                Action<long, long> evictCallback = null, LightEpoch epoch = null, Action<CommitInfo> flushCallback = null, ILogger logger = null)
             : base(settings, comparer, evictCallback, epoch, flushCallback, logger)
         {
             overflowPagePool = new OverflowPool<PageUnit>(4, p =>
@@ -497,15 +498,15 @@ namespace FASTER.core
         /// <summary>
         /// Iterator interface for pull-scanning FASTER log
         /// </summary>
-        public override IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode) 
-            => new VariableLengthBlittableScanIterator<Key, Value>(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+        public override IFasterScanIterator<Key, Value> Scan(FasterKV<Key, Value> store, long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode) 
+            => new VariableLengthBlittableScanIterator<Key, Value>(store, this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
 
         /// <summary>
         /// Implementation for push-scanning FASTER log, called from LogAccessor
         /// </summary>
         internal override bool Scan<TScanFunctions>(FasterKV<Key, Value> store, long beginAddress, long endAddress, ref TScanFunctions scanFunctions, ScanBufferingMode scanBufferingMode)
         {
-            using VariableLengthBlittableScanIterator<Key, Value> iter = new(this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
+            using VariableLengthBlittableScanIterator<Key, Value> iter = new(store, this, beginAddress, endAddress, scanBufferingMode, epoch, logger: logger);
             return PushScanImpl(store, beginAddress, endAddress, ref scanFunctions, iter);
         }
 
@@ -514,14 +515,14 @@ namespace FASTER.core
         /// </summary>
         internal override bool IterateKeyVersions<TScanFunctions>(FasterKV<Key, Value> store, ref Key key, long beginAddress, ref TScanFunctions scanFunctions)
         {
-            using VariableLengthBlittableScanIterator<Key, Value> iter = new(this, store.comparer, beginAddress, epoch, logger: logger);
+            using VariableLengthBlittableScanIterator<Key, Value> iter = new(store, this, store.comparer, beginAddress, epoch, logger: logger);
             return IterateKeyVersionsImpl(store, ref key, beginAddress, ref scanFunctions, iter);
         }
 
         /// <inheritdoc />
         internal override void MemoryPageScan(long beginAddress, long endAddress, IObserver<IFasterScanIterator<Key, Value>> observer)
         {
-            using var iter = new VariableLengthBlittableScanIterator<Key, Value>(this, beginAddress, endAddress, ScanBufferingMode.NoBuffering, epoch, true, logger: logger);
+            using var iter = new VariableLengthBlittableScanIterator<Key, Value>(store: null, this, beginAddress, endAddress, ScanBufferingMode.NoBuffering, epoch, true, logger: logger);
             observer?.OnNext(iter);
         }
 

--- a/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
@@ -148,7 +148,7 @@ namespace FASTER.core
 
                 nextAddress = currentAddress + recordSize;
 
-                recordInfo = ref hlog.GetInfo(physicalAddress);
+                recordInfo = hlog.GetInfo(physicalAddress);
                 if (recordInfo.SkipOnScan || recordInfo.IsNull())
                 {
                     epoch?.Suspend();

--- a/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
+++ b/cs/src/core/Allocator/VarLenBlittableScanIterator.cs
@@ -14,6 +14,7 @@ namespace FASTER.core
     /// </summary>
     public sealed class VariableLengthBlittableScanIterator<Key, Value> : ScanIteratorBase, IFasterScanIterator<Key, Value>, IPushScanIterator<Key>
     {
+        private readonly FasterKV<Key, Value> store;
         private readonly VariableLengthBlittableAllocator<Key, Value> hlog;
         private readonly IFasterEqualityComparer<Key> comparer;
         private readonly BlittableFrame frame;
@@ -26,6 +27,7 @@ namespace FASTER.core
         /// <summary>
         /// Constructor
         /// </summary>
+        /// <param name="store"></param>
         /// <param name="hlog"></param>
         /// <param name="beginAddress"></param>
         /// <param name="endAddress"></param>
@@ -33,9 +35,11 @@ namespace FASTER.core
         /// <param name="epoch">Epoch to use for protection; may be null if <paramref name="forceInMemory"/> is true.</param>
         /// <param name="forceInMemory">Provided address range is known by caller to be in memory, even if less than HeadAddress</param>
         /// <param name="logger"></param>
-        internal VariableLengthBlittableScanIterator(VariableLengthBlittableAllocator<Key, Value> hlog, long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode, LightEpoch epoch, bool forceInMemory = false, ILogger logger = null)
+        internal VariableLengthBlittableScanIterator(FasterKV<Key, Value> store, VariableLengthBlittableAllocator<Key, Value> hlog, long beginAddress, long endAddress, 
+                ScanBufferingMode scanBufferingMode, LightEpoch epoch, bool forceInMemory = false, ILogger logger = null)
             : base(beginAddress == 0 ? hlog.GetFirstValidLogicalAddress(0) : beginAddress, endAddress, scanBufferingMode, epoch, hlog.LogPageSizeBits, logger: logger)
         {
+            this.store = store;
             this.hlog = hlog;
             this.forceInMemory = forceInMemory;
             if (frameSize > 0)
@@ -45,9 +49,10 @@ namespace FASTER.core
         /// <summary>
         /// Constructor for use with tail-to-head push iteration of the passed key's record versions
         /// </summary>
-        internal VariableLengthBlittableScanIterator(VariableLengthBlittableAllocator<Key, Value> hlog, IFasterEqualityComparer<Key> comparer, long beginAddress, LightEpoch epoch, ILogger logger = null)
+        internal VariableLengthBlittableScanIterator(FasterKV<Key, Value> store, VariableLengthBlittableAllocator<Key, Value> hlog, IFasterEqualityComparer<Key> comparer, long beginAddress, LightEpoch epoch, ILogger logger = null)
             : base(beginAddress == 0 ? hlog.GetFirstValidLogicalAddress(0) : beginAddress, hlog.GetTailAddress(), ScanBufferingMode.SinglePageBuffering, epoch, hlog.LogPageSizeBits, logger: logger)
         {
+            this.store = store;
             this.hlog = hlog;
             this.comparer = comparer;
             this.forceInMemory = false;
@@ -79,43 +84,16 @@ namespace FASTER.core
         /// <returns>True if record found, false if end of scan</returns>
         public unsafe bool GetNext(out RecordInfo recordInfo)
         {
-            if (!BeginGetNext(out recordInfo, out long headAddress, out int recordSize))
-                return false;
-
-            // We will return control to the caller, which means releasing epoch protection.
-            if (currentAddress >= headAddress || forceInMemory)
-            {
-                // Copy the entire record into bufferPool memory, so we do not have a ref to log data outside epoch protection.
-                memory?.Return();
-                memory = hlog.bufferPool.Get(recordSize);
-                Buffer.MemoryCopy((byte*)currentPhysicalAddress, memory.aligned_pointer, recordSize, recordSize);
-                currentPhysicalAddress = (long)memory.aligned_pointer;
-            }
-
-            return ((IPushScanIterator<Key>)this).EndGet();
-        }
-
-        bool IPushScanIterator<Key>.BeginGetNext(out RecordInfo recordInfo) => BeginGetNext(out recordInfo, out _, out _);
-
-        /// <summary>
-        /// Get next record and keep the epoch held while we call the user's scan functions
-        /// </summary>
-        /// <returns>True if record found, false if end of scan</returns>
-        internal bool BeginGetNext(out RecordInfo recordInfo, out long headAddress, out int recordSize)
-        {
             recordInfo = default;
 
             while (true)
             {
                 currentAddress = nextAddress;
                 if (currentAddress >= endAddress)
-                {
-                    headAddress = recordSize = 0;
                     return false;
-                }
 
                 epoch?.Resume();
-                headAddress = hlog.HeadAddress;
+                long headAddress = hlog.HeadAddress;
 
                 if (currentAddress < hlog.BeginAddress && !forceInMemory)
                 {
@@ -123,6 +101,7 @@ namespace FASTER.core
                     throw new FasterException("Iterator address is less than log BeginAddress " + hlog.BeginAddress);
                 }
 
+                // If currentAddress < headAddress and we're not buffering and not guaranteeing the records are in memory, fail.
                 if (frameSize == 0 && currentAddress < headAddress && !forceInMemory)
                 {
                     epoch?.Suspend();
@@ -136,7 +115,7 @@ namespace FASTER.core
                     BufferAndLoad(currentAddress, currentPage, currentPage % frameSize, headAddress, endAddress);
 
                 long physicalAddress = GetPhysicalAddress(currentAddress, headAddress, currentPage, offset);
-                recordSize = hlog.GetRecordSize(physicalAddress).Item2;
+                int recordSize = hlog.GetRecordSize(physicalAddress).Item2;
 
                 // If record does not fit on page, skip to the next page.
                 if ((currentAddress & hlog.PageSizeMask) + recordSize > hlog.PageSize)
@@ -155,8 +134,38 @@ namespace FASTER.core
                     continue;
                 }
 
-                // Success; defer epoch?.Suspend(); to EndGet
                 currentPhysicalAddress = physicalAddress;
+
+                // We will return control to the caller, which means releasing epoch protection, and we don't want the caller to lock.
+                // Copy the entire record into bufferPool memory, so we do not have a ref to log data outside epoch protection.
+                // Lock to ensure no value tearing while copying to temp storage.
+                memory?.Return();
+                memory = null;
+                if (currentAddress >= headAddress || forceInMemory)
+                {
+                    OperationStackContext<Key, Value> stackCtx = default;
+                    try
+                    {
+                        // GetKey() and GetLockableInfo() should work but for safety and consistency with other allocators use physicalAddress.
+                        if (currentAddress >= headAddress && store is not null)
+                            store.LockForScan(ref stackCtx, ref hlog.GetKey(physicalAddress), ref hlog.GetInfo(physicalAddress));
+
+                        memory = hlog.bufferPool.Get(recordSize);
+                        unsafe
+                        { 
+                            Buffer.MemoryCopy((byte*)currentPhysicalAddress, memory.aligned_pointer, recordSize, recordSize);
+                            currentPhysicalAddress = (long)memory.aligned_pointer;
+                        }
+                    }
+                    finally
+                    {
+                        if (stackCtx.recSrc.HasLock)
+                            store.UnlockForScan(ref stackCtx, ref GetKey(), ref ((IPushScanIterator<Key>)this).GetLockableInfo());
+                    }
+                }
+
+                // Success
+                epoch?.Suspend();
                 return true;
             }
         }
@@ -202,7 +211,7 @@ namespace FASTER.core
             }
         }
 
-        bool IPushScanIterator<Key>.EndGet()
+        bool IPushScanIterator<Key>.EndGetPrevInMemory()
         {
             epoch?.Suspend();
             return true;

--- a/cs/src/core/Compaction/FASTERCompaction.cs
+++ b/cs/src/core/Compaction/FASTERCompaction.cs
@@ -42,7 +42,7 @@ namespace FASTER.core
             var lf = new LogCompactionFunctions<Key, Value, Input, Output, Context, Functions>(functions);
             using var fhtSession = For(lf).NewSession<LogCompactionFunctions<Key, Value, Input, Output, Context, Functions>>(sessionVariableLengthStructSettings: sessionVariableLengthStructSettings);
 
-            using (var iter1 = Log.Scan(Log.BeginAddress, untilAddress, allowMutable: true))
+            using (var iter1 = Log.Scan(Log.BeginAddress, untilAddress))
             {
                 long numPending = 0;
                 while (iter1.GetNext(out var recordInfo))
@@ -95,7 +95,7 @@ namespace FASTER.core
             using (var tempKv = new FasterKV<Key, Value>(IndexSize, new LogSettings { LogDevice = new NullDevice(), ObjectLogDevice = new NullDevice() }, comparer: Comparer, variableLengthStructSettings: variableLengthStructSettings, loggerFactory: loggerFactory))
             using (var tempKvSession = tempKv.NewSession<Input, Output, Context, Functions>(functions))
             {
-                using (var iter1 = Log.Scan(hlog.BeginAddress, untilAddress, allowMutable: true))
+                using (var iter1 = Log.Scan(hlog.BeginAddress, untilAddress))
                 {
                     while (iter1.GetNext(out var recordInfo))
                     {
@@ -117,7 +117,7 @@ namespace FASTER.core
                     ScanImmutableTailToRemoveFromTempKv(ref untilAddress, scanUntil, tempKvSession);
 
                 var numPending = 0;
-                using var iter3 = tempKv.Log.Scan(tempKv.Log.BeginAddress, tempKv.Log.TailAddress, allowMutable: true);
+                using var iter3 = tempKv.Log.Scan(tempKv.Log.BeginAddress, tempKv.Log.TailAddress);
                 while (iter3.GetNext(out var recordInfo))
                 {
                     if (recordInfo.Tombstone)
@@ -151,7 +151,7 @@ namespace FASTER.core
         private void ScanImmutableTailToRemoveFromTempKv<Input, Output, Context, Functions>(ref long untilAddress, long scanUntil, ClientSession<Key, Value, Input, Output, Context, Functions> tempKvSession)
             where Functions : IFunctions<Key, Value, Input, Output, Context>
         {
-            using var iter = Log.Scan(untilAddress, scanUntil, allowMutable: true);
+            using var iter = Log.Scan(untilAddress, scanUntil);
             while (iter.GetNext(out var _))
             {
                 tempKvSession.Delete(ref iter.GetKey(), default, 0);

--- a/cs/src/core/Index/Common/RecordMetadata.cs
+++ b/cs/src/core/Index/Common/RecordMetadata.cs
@@ -6,17 +6,17 @@ namespace FASTER.core
     /// <summary>
     /// A structure carrying metadata about a record in the log.
     /// </summary>
-    public struct RecordMetadata
+    public readonly struct RecordMetadata
     {
         /// <summary>
         /// The <see cref="RecordInfo"/> header of the record.
         /// </summary>
-        public RecordInfo RecordInfo;
+        public readonly RecordInfo RecordInfo;
 
         /// <summary>
         /// The logical address of the record.
         /// </summary>
-        public long Address;
+        public readonly long Address;
 
         internal RecordMetadata(RecordInfo recordInfo, long address = Constants.kInvalidAddress)
         {

--- a/cs/src/core/Index/FASTER/Implementation/RecordSource.cs
+++ b/cs/src/core/Index/FASTER/Implementation/RecordSource.cs
@@ -111,7 +111,7 @@ namespace FASTER.core
                 EphemeralLockResult.Success => "S",
                 EphemeralLockResult.Failed => "F",
                 EphemeralLockResult.HoldForSeal => "H",
-                _ => "unknown"
+                _ => "none"
             };
             return $"lla {AbsoluteAddress(LatestLogicalAddress)}{llaRC}, la {AbsoluteAddress(LogicalAddress)}{laRC}, lrcla {AbsoluteAddress(LowestReadCacheLogicalAddress)},"
                  + $" logSrc {bstr(HasMainLogSrc)}, rcSrc {bstr(HasReadCacheSrc)}, tLock {bstr(HasTransientLock)}, eLock {ephLockResult}";

--- a/cs/src/core/Index/FASTER/LogAccessor.cs
+++ b/cs/src/core/Index/FASTER/LogAccessor.cs
@@ -253,19 +253,9 @@ namespace FASTER.core
         /// Scan the log given address range, returns all records with address less than endAddress
         /// </summary>
         /// <returns>Scan iterator instance</returns>
-        public IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering) 
-            => Scan(beginAddress, endAddress, scanBufferingMode, allowMutable: false);
-
-        internal IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, bool allowMutable)
-            => Scan(beginAddress, endAddress, ScanBufferingMode.DoublePageBuffering, allowMutable);
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode, bool allowMutable)
-        {
-            if (endAddress >= fht.hlog.SafeReadOnlyAddress && !allowMutable && fht.IsLocking)
-                throw new FasterException($"Cannot run pull Scan() in the mutable region when locking is enabled; use the form that takes {nameof(IScanIteratorFunctions<Key, Value>)} instead");
-            return allocator.Scan(beginAddress, endAddress, scanBufferingMode);
-        }
+        public IFasterScanIterator<Key, Value> Scan(long beginAddress, long endAddress, ScanBufferingMode scanBufferingMode = ScanBufferingMode.DoublePageBuffering) 
+            => allocator.Scan(store: null, beginAddress, endAddress, scanBufferingMode);
 
         /// <summary>
         /// Scan the log given address range, returns all records with address less than endAddress

--- a/cs/test/BlittableIterationTests.cs
+++ b/cs/test/BlittableIterationTests.cs
@@ -42,11 +42,6 @@ namespace FASTER.test
             internal long numRecords;
             internal int stopAt;
 
-            public bool OnStart(long beginAddress, long endAddress) => true;
-
-            public bool ConcurrentReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords) 
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
-
             public bool SingleReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords)
             {
                 if (keyMultToValue > 0)
@@ -54,8 +49,10 @@ namespace FASTER.test
                 return stopAt != ++numRecords;
             }
 
+            public bool ConcurrentReader(ref KeyStruct key, ref ValueStruct value, RecordMetadata recordMetadata, long numberOfRecords)
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
+            public bool OnStart(long beginAddress, long endAddress) => true;
             public void OnException(Exception exception, long numberOfRecords) { }
-
             public void OnStop(bool completed, long numberOfRecords) { }
         }
 
@@ -73,7 +70,6 @@ namespace FASTER.test
             BlittablePushIterationTestFunctions scanIteratorFunctions = new();
 
             const int totalRecords = 500;
-            var start = fht.Log.TailAddress;
 
             void iterateAndVerify(int keyMultToValue, int expectedRecs)
             {

--- a/cs/test/GenericIterationTests.cs
+++ b/cs/test/GenericIterationTests.cs
@@ -66,11 +66,6 @@ namespace FASTER.test
             internal long numRecords;
             internal int stopAt;
 
-            public bool OnStart(long beginAddress, long endAddress) => true;
-
-            public bool ConcurrentReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords)
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
-
             public bool SingleReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords)
             {
                 if (keyMultToValue > 0)
@@ -78,8 +73,10 @@ namespace FASTER.test
                 return stopAt != ++numRecords;
             }
 
+            public bool ConcurrentReader(ref MyKey key, ref MyValue value, RecordMetadata recordMetadata, long numberOfRecords)
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
+            public bool OnStart(long beginAddress, long endAddress) => true;
             public void OnException(Exception exception, long numberOfRecords) { }
-
             public void OnStop(bool completed, long numberOfRecords) { }
         }
 
@@ -93,7 +90,6 @@ namespace FASTER.test
             GenericPushIterationTestFunctions scanIteratorFunctions = new();
 
             const int totalRecords = 2000;
-            var start = fht.Log.TailAddress;
 
             void iterateAndVerify(int keyMultToValue, int expectedRecs)
             {

--- a/cs/test/VarLenBlittableIterationTests.cs
+++ b/cs/test/VarLenBlittableIterationTests.cs
@@ -4,7 +4,6 @@
 using FASTER.core;
 using NUnit.Framework;
 using System;
-using static FASTER.test.BlittableIterationTests;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using static FASTER.test.TestUtils;
@@ -46,11 +45,6 @@ namespace FASTER.test
             internal long numRecords;
             internal int stopAt;
 
-            public bool OnStart(long beginAddress, long endAddress) => true;
-
-            public bool ConcurrentReader(ref Key key, ref VLValue value, RecordMetadata recordMetadata, long numberOfRecords)
-                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
-
             public bool SingleReader(ref Key key, ref VLValue value, RecordMetadata recordMetadata, long numberOfRecords)
             {
                 if (keyMultToValue > 0)
@@ -58,8 +52,10 @@ namespace FASTER.test
                 return stopAt != ++numRecords;
             }
 
+            public bool ConcurrentReader(ref Key key, ref VLValue value, RecordMetadata recordMetadata, long numberOfRecords)
+                => SingleReader(ref key, ref value, recordMetadata, numberOfRecords);
+            public bool OnStart(long beginAddress, long endAddress) => true;
             public void OnException(Exception exception, long numberOfRecords) { }
-
             public void OnStop(bool completed, long numberOfRecords) { }
         }
 
@@ -77,7 +73,6 @@ namespace FASTER.test
             VarLenBlittablePushIterationTestFunctions scanIteratorFunctions = new();
 
             const int totalRecords = 500;
-            var start = fht.Log.TailAddress;
 
             void iterateAndVerify(int keyMultToValue, int expectedRecs)
             {


### PR DESCRIPTION
### Description

The PR contains changes in multiple files related to the push-based scan interface implementation for FASTER log. Here are the summarized changes:

- Added a new parameter `store` of type `FasterKV<Key, Value>` to the `Scan` method in classes `BlittableAllocator`, `GenericAllocator`, and `VarLenBlittableAllocator`.
- Updated the implementation for `Scan` methods in the above-mentioned classes to use the `store` parameter when creating the corresponding scan iterator instances.
- Updated the `BeginGetNext` method in the scan iterators to exclude the logic related to handling mutable regions when not needed.
- Updated the `ConcurrentReader` and `SingleReader` methods in the scan iterator functions to simplify the logic and remove redundant checks.
- Added the `ProcessNonTailmostMainKvRecord` method in the FASTERKV class to handle non-tailmost records in the tag chain during push-based iteration.
- Updated the tests (`BlittableIterationTests.cs`, `GenericIterationTests.cs`, `VarLenBlittableIterationTests.cs`) to align with the changes made to the push-based scan interface implementation.

These changes enhance the push-based scan interface functionality for FASTER log and improve the push-based iteration testing scenarios.